### PR TITLE
Disable software update

### DIFF
--- a/resources/etc/OpenBoard.config
+++ b/resources/etc/OpenBoard.config
@@ -1,8 +1,7 @@
 [App]
-HideCheckForSoftwareUpdate=false
+HideCheckForSoftwareUpdate=true
 HideSwapDisplayScreens=true
-EnableAutomaticSoftwareUpdates=true
-EnableSoftwareUpdates=true
+EnableAutomaticSoftwareUpdates=false
 EnableStartupHints=true
 FavoriteToolURIs=openboardtool://openboard/mask, openboardtool://ruler, openboardtool://compass, openboardtool://protractor, openboardtool://triangle, openboardtool://magnifier, openboardtool://cache
 IsInSoftwareUpdateProcess=false

--- a/src/core/UBPreferencesController.cpp
+++ b/src/core/UBPreferencesController.cpp
@@ -85,6 +85,7 @@ UBPreferencesController::UBPreferencesController(QWidget *parent)
     mPreferencesWindow = new UBPreferencesDialog(this,parent, Qt::Dialog);
     mPreferencesUI = new Ui::preferencesDialog();  // deleted in destructor
     mPreferencesUI->setupUi(mPreferencesWindow);
+    mPreferencesUI->softwareUpdateGroupBox->hide();     // disable check for software update
     adjustScreensPreferences();
 
     connect(UBApplication::displayManager, &UBDisplayManager::availableScreenCountChanged, this, &UBPreferencesController::adjustScreensPreferences);


### PR DESCRIPTION
For packages maintained by a Linux distribution, a software update check is not relevant. Also the import of historical OpenSankore documents is not a use case for those packages. This PR disables and hides the software update check and the OpenSankore document update check. It

- disables the checks in the settings by default, and
- hides the associated checkboxes in the preferences.

This PR may be used as a source for a patch when building OpenBoard for a distribution.